### PR TITLE
gitignore update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ Homestead.json
 Homestead.yaml
 npm-debug.log
 yarn-error.log
+public/js/front.js
+public/js/app.js
+public/css/app.css
+public/mix-manifest.json


### PR DESCRIPTION
Aggiornamento gitignore per i file creati da npm run dev/watch che non dobbiamo pushare nella repo.